### PR TITLE
Fix flaky Test  net.bytebuddy.description.type.TypeDescriptionGenericBuilderTest#testTypeAnnotationExceptionType

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericBuilderTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericBuilderTest.java
@@ -14,8 +14,8 @@ import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.Collections;
-
 import java.util.Comparator;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,11 +43,10 @@ public class TypeDescriptionGenericBuilderTest extends AbstractTypeDescriptionGe
 
     protected TypeDescription.Generic describeExceptionType(Method method, int index) {
         Type[] exceptionTypes = method.getGenericExceptionTypes();
-        // Sort type array
         Arrays.sort(exceptionTypes, new Comparator<Type>() {
             @Override
-            public int compare(Type o1, Type o2) {
-                return o1.getTypeName().compareTo(o2.getTypeName());
+            public int compare(Type t1, Type t2) {
+                return t1.getTypeName().compareTo(t2.getTypeName());
             }
         });
         return describe(exceptionTypes[index], new TypeDescription.Generic.AnnotationReader.Delegator.ForLoadedExecutableExceptionType(method, index))

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericBuilderTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericBuilderTest.java
@@ -12,8 +12,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
+import java.util.Arrays;
 import java.util.Collections;
 
+import java.util.Comparator;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,7 +42,15 @@ public class TypeDescriptionGenericBuilderTest extends AbstractTypeDescriptionGe
     }
 
     protected TypeDescription.Generic describeExceptionType(Method method, int index) {
-        return describe(method.getGenericExceptionTypes()[index], new TypeDescription.Generic.AnnotationReader.Delegator.ForLoadedExecutableExceptionType(method, index))
+        Type[] exceptionTypes = method.getGenericExceptionTypes();
+        // Sort type array
+        Arrays.sort(exceptionTypes, new Comparator<Type>() {
+            @Override
+            public int compare(Type o1, Type o2) {
+                return o1.getTypeName().compareTo(o2.getTypeName());
+            }
+        });
+        return describe(exceptionTypes[index], new TypeDescription.Generic.AnnotationReader.Delegator.ForLoadedExecutableExceptionType(method, index))
                 .accept(TypeDescription.Generic.Visitor.Substitutor.ForAttachment.of(new MethodDescription.ForLoadedMethod(method)));
     }
 


### PR DESCRIPTION
The test `net.bytebuddy.description.type.TypeDescriptionGenericBuilderTest.testTypeAnnotationExceptionType` tests the various annotations present on the exception type of a method.
Digging into the test, we find that `TypeDescriptionGenericBuilderTest.describeExceptionType` uses index based access to get the annotations on the exception type.
The test is failing because it internally depends on the order of the annotations in the returned list.

The root cause is underlying call to Java's reflection API method -> `java.lang.reflect.Method.getGenericExceptionTypes()` returns an array of exception types . However, the order of the exception types in the array is not guaranteed to be in the same order for each execution. Thus sometimes , the  test fails due to different order than expected 

This PR proposes to sort the exception types returned by the reflection API method and make it determinist